### PR TITLE
Added information about the Apple TV 4K 3rd Gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Apple devices(iPhone, iPad, iPod Touch, Apple TV, Apple Watch, HomePod,) model l
 "AppleTV5,3":                                      Apple TV 4
 "AppleTV6,2":                                      Apple TV 4K
 "AppleTV11,1":                                     Apple TV 4K 2
+"AppleTV14,1":                                     Apple TV 4K 3
 ```
 
 ## Apple Watch


### PR DESCRIPTION
The information is taken from here:

https://everymac.com/systems/apple/apple-tv/specs/apple-tv-4k-3rd-gen-a15-2022-a2737-wifi-only-specs.html
https://everymac.com/systems/apple/apple-tv/specs/apple-tv-4k-3rd-gen-a15-2022-a2843-wifi-ethernet-thread-specs.html
