### PR TITLE
Added information about iPhone 17, iPhone Air

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Apple devices(iPhone, iPad, iPod Touch, Apple TV, Apple Watch, HomePod,) model l
 "iPhone17,1":                                      iPhone 16 Pro
 "iPhone17,2":                                      iPhone 16 Pro Max
 "iPhone17,5":                                      iPhone 16e
+"iPhone18,1":                                      iPhone 17 Pro
+"iPhone18,2":                                      iPhone 16 Pro Max
+"iPhone18,3":                                      iPhone 17
+"iPhone18,4":                                      iPhone Air
 ```
 
 ## iPad

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Apple devices(iPhone, iPad, iPod Touch, Apple TV, Apple Watch, HomePod,) model l
 "iPhone17,2":                                      iPhone 16 Pro Max
 "iPhone17,5":                                      iPhone 16e
 "iPhone18,1":                                      iPhone 17 Pro
-"iPhone18,2":                                      iPhone 16 Pro Max
+"iPhone18,2":                                      iPhone 17 Pro Max
 "iPhone18,3":                                      iPhone 17
 "iPhone18,4":                                      iPhone Air
 ```


### PR DESCRIPTION
Information taken from AppleDB:

- [iPhone Air](https://appledb.dev/device/iPhone18,4.html)
- [iPhone 17 Pro](https://appledb.dev/device/iPhone-17-Pro-series.html)
- [iPhone 17](https://appledb.dev/device/iPhone18,3.html)