### PR TITLE
Added information about iPad Pro 11'' (M5), iPad Pro 13'' (M5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Apple devices(iPhone, iPad, iPod Touch, Apple TV, Apple Watch, HomePod,) model l
 "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":    iPad Pro 11-inch 3
 "iPad14,3", "iPad14,4":                            iPad Pro 11-inch (M2)
 "iPad16,3", "iPad16,4":                            iPad Pro 11-inch (M4)
+"iPad17,1", "iPad17,2":                            iPad Pro 11-inch (M5)
 "iPad6,7", "iPad6,8":                              iPad Pro 12.9-inch
 "iPad7,1", "iPad7,2":                              iPad Pro 12.9-inch 2
 "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8":        iPad Pro 12.9-inch 3
@@ -101,6 +102,7 @@ Apple devices(iPhone, iPad, iPod Touch, Apple TV, Apple Watch, HomePod,) model l
 "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":  iPad Pro 12.9-inch 5
 "iPad14,5", "iPad14,6":                            iPad Pro 12.9-inch (M2)
 "iPad16,5", "iPad16,6":                            iPad Pro 13-inch (M4)
+"iPad17,3", "iPad17,4":                            iPad Pro 13-inch (M5)
 ```
 
 ## iPod


### PR DESCRIPTION
Source:

- https://theapplewiki.com/wiki/IPad_Pro_11-inch_(M5);
- https://theapplewiki.com/wiki/IPad_Pro_13-inch_(M5).